### PR TITLE
feat: Prevent text selection when choosing a command

### DIFF
--- a/src/components/RadialMenu.svelte
+++ b/src/components/RadialMenu.svelte
@@ -7,6 +7,7 @@
 
 <script lang="ts">
 	import { getAngleDifference, normalizeAngle } from '$/helpers/math';
+	import { setUserSelect } from '$/helpers/style';
 	import { sineInOut } from 'svelte/easing';
 	import { spring } from 'svelte/motion';
 	import { scale } from 'svelte/transition';
@@ -109,26 +110,19 @@
 		return `--rotate: ${rotate}deg`;
 	}
 
-	function setBodyUserSelect(val: string) {
-		document.body.style.userSelect = val;
-		document.body.style.webkitUserSelect = val;
-		// @ts-ignore
-		document.body.style.webkitTouchCallout = val;
-	}
-
 	function onMouseDown(e: MouseEvent) {
 		const el = e.target as HTMLElement;
 		if (!['BODY', 'HTML', 'MAIN'].includes(el.tagName)) return;
 		clickCoords = [e.clientX, e.clientY];
 		document.body.style.cursor = 'move';
-		setBodyUserSelect('none');
+		setUserSelect(document.body, 'none');
 	}
 
 	function onTouchStart(e: TouchEvent) {
 		const el = e.target as HTMLElement;
 		if (!['BODY', 'HTML', 'MAIN'].includes(el.tagName)) return;
 		clickCoords = [e.touches[0].clientX, e.touches[0].clientY];
-		setBodyUserSelect('none');
+		setUserSelect(document.body, 'none');
 	}
 </script>
 
@@ -140,6 +134,7 @@
 	on:touchend={() => {
 		clickCoords = null;
 		mouseCoords = null;
+		setUserSelect(document.body, 'initial');
 	}}
 	on:mousedown={onMouseDown}
 	on:mousemove={(e) => {
@@ -149,10 +144,7 @@
 		clickCoords = null;
 		mouseCoords = null;
 		document.body.style.cursor = 'initial';
-		setBodyUserSelect('initial');
-	}}
-	on:touchend={() => {
-		setBodyUserSelect('initial');
+		setUserSelect(document.body, 'initial');
 	}}
 />
 

--- a/src/components/RadialMenu.svelte
+++ b/src/components/RadialMenu.svelte
@@ -109,17 +109,25 @@
 		return `--rotate: ${rotate}deg`;
 	}
 
+	function setBodyUserSelect(val: string) {
+		document.body.style.userSelect = val;
+		document.body.style.webkitUserSelect = val;
+		// @ts-ignore
+		document.body.style.webkitTouchCallout = val;
+	}
+
 	function onMouseDown(e: MouseEvent) {
 		const el = e.target as HTMLElement;
 		if (!['BODY', 'HTML', 'MAIN'].includes(el.tagName)) return;
 		clickCoords = [e.clientX, e.clientY];
-		document.body.style.cursor = 'move';
+		setBodyUserSelect('none');
 	}
 
 	function onTouchStart(e: TouchEvent) {
 		const el = e.target as HTMLElement;
 		if (!['BODY', 'HTML', 'MAIN'].includes(el.tagName)) return;
 		clickCoords = [e.touches[0].clientX, e.touches[0].clientY];
+		setBodyUserSelect('none');
 	}
 </script>
 
@@ -140,6 +148,10 @@
 		clickCoords = null;
 		mouseCoords = null;
 		document.body.style.cursor = 'initial';
+		setBodyUserSelect('initial');
+	}}
+	on:touchend={() => {
+		setBodyUserSelect('initial');
 	}}
 />
 

--- a/src/components/RadialMenu.svelte
+++ b/src/components/RadialMenu.svelte
@@ -120,6 +120,7 @@
 		const el = e.target as HTMLElement;
 		if (!['BODY', 'HTML', 'MAIN'].includes(el.tagName)) return;
 		clickCoords = [e.clientX, e.clientY];
+		document.body.style.cursor = 'move';
 		setBodyUserSelect('none');
 	}
 

--- a/src/helpers/style.ts
+++ b/src/helpers/style.ts
@@ -1,0 +1,6 @@
+export function setUserSelect(element: HTMLElement, value: string) {
+    element.style.userSelect = value;
+    element.style.webkitUserSelect = value;
+    // @ts-ignore
+    element.style.webkitTouchCallout = value;
+}


### PR DESCRIPTION
This PR enables users to open the menu without selecting text around it.
Still some niche things happening with double click on safari mobile, don't think we need to address them in this PR.

#2 